### PR TITLE
Fixed admin error

### DIFF
--- a/taggit_suggest/admin.py
+++ b/taggit_suggest/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
 from taggit.admin import TaggedItemInline
-from taggit.contrib.suggest.models import TagKeyword, TagRegex
+from taggit_suggest.models import TagKeyword, TagRegex
 from taggit.models import Tag
 
 


### PR DESCRIPTION
admin.py was referencing the old location of the suggest models. Updated to reference taggit_suggest instead of taggit.contrib.suggest.
